### PR TITLE
Add configurable KV cache for auth.test calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ bower_components
 
 build/Release
 
+# editors
+.vscode
+
 # Dependency directories
 
 node_modules/

--- a/src/serializable-slack-api-response.ts
+++ b/src/serializable-slack-api-response.ts
@@ -1,0 +1,38 @@
+import { SlackAPIResponse } from "slack-web-api-client";
+
+export type SerializableSlackAPIResponse<T extends SlackAPIResponse> = Omit<T, "headers"> & {
+  headers: Record<string, string>;
+};
+
+/**
+ * Converts a SlackAPIResponse to a SerializableSlackAPIResponse.
+ * Serializes the headers value.
+ * @param response - The SlackAPIResponse to convert
+ * @returns The converted SerializableSlackAPIResponse
+ */
+export function toSerializableSlackAPIResponse<T extends SlackAPIResponse>(response: T): SerializableSlackAPIResponse<T> {
+  // Replace the Headers entries with a serializable object
+  const { headers, ...rest } = response;
+  return {
+    ...rest,
+    headers: Object.fromEntries(headers.entries()),
+  };
+}
+
+/**
+ * Converts a SerializableSlackAPIResponse to a SlackAPIResponse.
+ * Deserializes the headers value.
+ * @param response - The SerializableSlackAPIResponse to convert
+ * @returns The converted SlackAPIResponse
+ */
+export function fromSerializableSlackAPIResponse<T extends SlackAPIResponse>(response: SerializableSlackAPIResponse<T>): SlackAPIResponse {
+  // Reconstruct the Headers object
+  const headers = new Headers(response.headers);
+
+  // Rebuild the original object with Headers restored
+  const { headers: serializedHeaders, ...rest } = response;
+  return {
+    ...rest,
+    headers,
+  };
+}


### PR DESCRIPTION
Fixes https://github.com/slack-edge/slack-edge/issues/59 for slack-cloudflare-workers